### PR TITLE
update：更新 gopsutil 版本

### DIFF
--- a/glc/go.mod
+++ b/glc/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gotoeasy/glang v0.21.4
 	github.com/rabbitmq/amqp091-go v1.10.0
-	github.com/shirou/gopsutil v3.21.11+incompatible
+	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/syndtr/goleveldb v1.0.0
 )
 
@@ -50,7 +50,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/rs/xid v1.6.0 // indirect
-	github.com/shirou/gopsutil/v3 v3.24.5 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/glc/ldb/sysmnt/storage_data.go
+++ b/glc/ldb/sysmnt/storage_data.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/gotoeasy/glang/cmn"
-	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/v3/disk"
 )
 
 type StorageResult struct {


### PR DESCRIPTION
fix：旧版本的 gopsutil 使用了 macOS 12.0 中已废弃的 IOMasterPort API，导致编译时出现警告。 # github.com/shirou/gopsutil/disk
iostat_darwin.c:28:2: warning: 'IOMasterPort' is deprecated: first deprecated in macOS 12.0 [-Wdeprecated-declarations] /Applications/Xcode-16.4.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOKit.framework/Headers/IOKitLib.h:143:1: note: 'IOMasterPort' has been explicitly marked deprecated here